### PR TITLE
When a segfault occurs, print a backtrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-OPTS=-O2 -Wall -lfuse -lgit2
+# -rdynamic to allow printing a backtrace on as segfault
+OPTS=-rdynamic -O2 -Wall -lfuse -lgit2
 
 git-fs: clean
 	gcc ${OPTS} -o git-fs git-fs.c


### PR DESCRIPTION
When using git-fs for the root filesystem, debugging becomes a bit
problematic. To assist here, automatically printing a backtrace might
help. It does seem that getting a backtrace doesn't always work,
unortunately.